### PR TITLE
添加task-as-usize feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,6 @@ prio-level-8 = []
 
 prio-level-16 = []
 
-default = ["no-simul", "prio-level-8"]
+default = ["no-simul"]
 
-
-
-
+task-as-usize = []

--- a/src/waker.rs
+++ b/src/waker.rs
@@ -18,9 +18,16 @@ struct WakerData {
 }
 
 impl WakerData {
+    #[cfg(not(feature = "task-as-usize"))]
     fn wake(&self) {
         let priority = unsafe { (*self.task_ref.as_ptr()).priority.load(Ordering::Acquire) };
         self.hw.stask(self.task_ref, self.process_id, priority as usize);
+    }
+
+    #[cfg(feature = "task-as-usize")]
+    fn wake(&self) {
+        let priority = unsafe { (*self.task_ref.as_ptr()).priority.load(Ordering::Acquire) };
+        self.hw.stask(self.task_ref.as_ptr() as usize, self.process_id, priority as usize);
     }
 }
 


### PR DESCRIPTION
添加`task-as-usize` feature，允许以`usize`格式调度其它类型任务的指针。